### PR TITLE
Fixed Python3 error.

### DIFF
--- a/suddendeath/__init__.py
+++ b/suddendeath/__init__.py
@@ -41,7 +41,9 @@ def main():
   if len(sys.argv) < 2:
     message = default_message
   else:
-    message = sys.argv[1].encode("utf-8").decode("utf-8")
+    message = sys.argv[1]
+    if sys.version_info.major == 2:
+      message = message.decode("utf-8")
 
   print(suddendeathmessage(message))
 


### PR DESCRIPTION
When running suddendeath on Python 3, following errors are occured.

```
$ suddendeath
Traceback (most recent call last):
  File "/Users/likr/local/python32/bin/suddendeath", line 9, in <module>
    load_entry_point('suddendeath==0.2.0', 'console_scripts', 'suddendeath')()
  File "/Users/likr/local/python32/lib/python3.2/site-packages/suddendeath/__init__.py", line 46, in main
    print((suddendeathmessage(message)))
  File "/Users/likr/local/python32/lib/python3.2/site-packages/suddendeath/__init__.py", line 30, in suddendeathmessage
    header = "＿" + "人"*header_chars + "＿"
TypeError: can't multiply sequence by non-int of type 'float'
$ suddendeath ぱいそん
Traceback (most recent call last):
  File "/Users/likr/local/python32/bin/suddendeath", line 9, in <module>
load_entry_point('suddendeath==0.2.0', 'console_scripts', 'suddendeath')()
  File "/Users/likr/local/python32/lib/python3.2/site-packages/suddendeath/__init__.py", line 44, in main
    message = sys.argv[1].decode("utf-8")
AttributeError: 'str' object has no attribute 'decode'
```

I fixed it.
